### PR TITLE
Converter should handle periods and not separate on them

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fullcontact/camelsnake "0.9.2-SNAPSHOT"
+(defproject fullcontact/camelsnake "0.10.0-SNAPSHOT"
   :description "String and keyword transformation between cases."
   :url "https://github.com/fullcontact/camelsnake"
   :license {:name "Eclipse Public License - v 1.0"

--- a/src/camelsnake/Converter.java
+++ b/src/camelsnake/Converter.java
@@ -7,6 +7,7 @@ public class Converter {
         LOWER,
         DIGIT,
         DASH,
+        DOT,
         UNDERSCORE,
         OTHER
     }
@@ -22,6 +23,8 @@ public class Converter {
             return Type.UNDERSCORE;
         } else if (ch == '-') {
             return Type.DASH;
+        } else if (ch == '.') {
+            return Type.DOT;
         } else {
             return Type.OTHER;
         }
@@ -53,7 +56,10 @@ public class Converter {
         for (int i = 0; i < in.length(); i++) {
             char ch = in.charAt(i);
             Type type = getCharType(ch);
-            if ((type != prevType
+            if (!(Type.DOT == type || Type.DOT == prevType ||
+                (in.length() > (i + 1) && Type.DOT == getCharType(in.charAt(i + 1))))
+                &&
+                (type != prevType
                     && (i - prevBoundary) > 0
                     && (Type.UPPER != prevType || Type.LOWER != type))
                     ||

--- a/test/camelsnake/core_test.clj
+++ b/test/camelsnake/core_test.clj
@@ -11,7 +11,8 @@
   (is (= (->snake_case "a_snake_case") "a_snake_case"))
   (is (= (->snake_case "f_o_o") "f_o_o"))
   (is (= (->snake_case "x_http_request") "x_http_request"))
-  (is (= (->snake_case "foo_x") "foo_x")))
+  (is (= (->snake_case "foo_x") "foo_x"))
+  (is (= (->snake_case "foo.bar_x") "foo.bar_x")))
 
 (deftest snake->camel-conversion
   (is (= (->camelCase "snake_case") "snakeCase"))
@@ -19,7 +20,8 @@
   (is (= (->camelCase "a_snake_case") "aSnakeCase"))
   (is (= (->camelCase "f_o_o") "fOO"))
   (is (= (->camelCase "x_http_request") "xHttpRequest"))
-  (is (= (->camelCase "foo_x") "fooX")))
+  (is (= (->camelCase "foo_x") "fooX"))
+  (is (= (->camelCase "foo.bar_x") "foo.barX")))
 
 (deftest snake->kebab-conversion
   (is (= (->kebab-case "snake_case") "snake-case"))
@@ -27,7 +29,8 @@
   (is (= (->kebab-case "a_snake_case") "a-snake-case"))
   (is (= (->kebab-case "f_o_o") "f-o-o"))
   (is (= (->kebab-case "x_http_request") "x-http-request"))
-  (is (= (->kebab-case "foo_x") "foo-x")))
+  (is (= (->kebab-case "foo_x") "foo-x"))
+  (is (= (->kebab-case "foo.bar_x") "foo.bar-x")))
 
 
 ;;; Camel input
@@ -39,7 +42,8 @@
   (is (= (->camelCase "ASnakeCase") "aSnakeCase"))
   (is (= (->camelCase "fOO") "fOo"))
   (is (= (->camelCase "xHttpRequest") "xHttpRequest"))
-  (is (= (->camelCase "fooX") "fooX")))
+  (is (= (->camelCase "fooX") "fooX"))
+  (is (= (->camelCase "foo.barX") "foo.barX")))
 
 (deftest camel->snake-conversion
   (is (= (->snake_case "snakeCase") "snake_case"))
@@ -49,7 +53,8 @@
   (is (= (->snake_case "FOO") "foo"))
   (is (= (->snake_case "FOo") "f_oo"))
   (is (= (->snake_case "xHttpRequest") "x_http_request"))
-  (is (= (->snake_case "fooX") "foo_x")))
+  (is (= (->snake_case "fooX") "foo_x"))
+  (is (= (->snake_case "foo.barX") "foo.bar_x")))
 
 (deftest camel->kebab-conversion
   (is (= (->kebab-case "snakeCase") "snake-case"))
@@ -58,7 +63,10 @@
   (is (= (->kebab-case "ASnakeCase") "a-snake-case"))
   (is (= (->kebab-case "FOO") "foo"))
   (is (= (->kebab-case "foO") "fo-o"))
-  (is (= (->kebab-case "HTTPRequest") "http-request")))
+  (is (= (->kebab-case "HTTPRequest") "http-request"))
+  (is (= (->kebab-case "FOO.HTTPServer") "foo.http-server"))
+  (is (= (->kebab-case "foo.Bar") "foo.bar"))
+  (is (= (->kebab-case "foo.bar") "foo.bar")))
 
 
 ;;; Kebab input
@@ -69,7 +77,8 @@
   (is (= (->kebab-case "a-snake-case") "a-snake-case"))
   (is (= (->kebab-case "foo") "foo"))
   (is (= (->kebab-case "fo-o") "fo-o"))
-  (is (= (->kebab-case "http-request") "http-request")))
+  (is (= (->kebab-case "http-request") "http-request"))
+  (is (= (->kebab-case "foo.bar-request") "foo.bar-request")))
 
 (deftest kebab->snake-conversion
   (is (= (->snake_case "snake-case") "snake_case"))
@@ -77,7 +86,8 @@
   (is (= (->snake_case "a-snake-case") "a_snake_case"))
   (is (= (->snake_case "f-o-o") "f_o_o"))
   (is (= (->snake_case "x-http-request") "x_http_request"))
-  (is (= (->snake_case "foo-x") "foo_x")))
+  (is (= (->snake_case "foo-x") "foo_x"))
+  (is (= (->snake_case "foo.bar-x") "foo.bar_x")))
 
 (deftest kebab->camel-conversion
   (is (= (->camelCase "snake-case") "snakeCase"))
@@ -85,7 +95,9 @@
   (is (= (->camelCase "a-snake-case") "aSnakeCase"))
   (is (= (->camelCase "f-oo") "fOo"))
   (is (= (->camelCase "x-http-request") "xHttpRequest"))
-  (is (= (->camelCase "foo-x") "fooX")))
+  (is (= (->camelCase "foo-x") "fooX"))
+  (is (= (->camelCase "foo.bar-x") "foo.barX"))
+  (is (= (->camelCase "foo.bar") "foo.bar")))
 
 
 (deftest case-conversions
@@ -98,4 +110,5 @@
   (is (= (->keyword "FooBARBaz") :foo-bar-baz))
   (is (= (->keyword "FOOBARBAZ") :foobarbaz))
   (is (= (->keyword "XFullContactAccountId") :x-full-contact-account-id))
-  (is (= (->keyword "iPod") :i-pod)))
+  (is (= (->keyword "iPod") :i-pod))
+  (is (= (->keyword "iPod.bar") :i-pod.bar)))


### PR DESCRIPTION
@skazhy 

Converter would turn something like `foo.bar` into `:foo-.-bar` for kebab case etc...

In general the conversion from camel to kebab and vice versa with periods was messed up. It was treating period as a separator just as if it were lower to upper or upper to lower. 